### PR TITLE
Add renv to Dockerfile and cli.R call

### DIFF
--- a/Code/CaseStudy2/renv.lock
+++ b/Code/CaseStudy2/renv.lock
@@ -4,7 +4,7 @@
     "Repositories": [
       {
         "Name": "CRAN",
-        "URL": "https://www.stats.bris.ac.uk/R"
+        "URL": "https://cloud.r-project.org"
       }
     ]
   },

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,16 @@ FROM rocker/r-ver:4.1.0
 
 WORKDIR /project
 
-CMD R -e "print('Hello, World!')"
+# renv
+COPY Code/CaseStudy2/renv.lock renv.lock
+RUN mkdir -p renv
+COPY Code/CaseStudy2/.Rprofile .Rprofile
+COPY Code/CaseStudy2/renv/activate.R renv/activate.R
+COPY Code/CaseStudy2/renv/settings.dcf renv/settings.dcf
+
+RUN R -e "renv::restore()"
+
+# DIMEX source code
+COPY Code/CaseStudy2 .
+
+CMD Rscript cli.R --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rocker/r-base:latest
 WORKDIR /project
 
 # R package dependencies
-RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev libgdal-dev
 
 # renv
 RUN mkdir -p renv

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /project
 
 # R package dependencies
 # RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev libgdal-dev libudunits2-dev
+RUN apt-get update && apt-get install -y libgdal-dev libudunits2-dev
 
 # renv
 RUN mkdir -p renv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM rocker/r-base:latest
+FROM rocker/tidyverse:latest
+# FROM rocker/r-base:latest
 
 WORKDIR /project
 
 # R package dependencies
-RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev libgdal-dev libudunits2-dev
+# RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev libgdal-dev libudunits2-dev
 
 # renv
 RUN mkdir -p renv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
-FROM rocker/r-ver:4.1.0
+FROM rocker/r-base:latest
 
 WORKDIR /project
 
+# R package dependencies
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev
+
 # renv
-COPY Code/CaseStudy2/renv.lock renv.lock
 RUN mkdir -p renv
+COPY Code/CaseStudy2/renv.lock renv.lock
 COPY Code/CaseStudy2/.Rprofile .Rprofile
 COPY Code/CaseStudy2/renv/activate.R renv/activate.R
 COPY Code/CaseStudy2/renv/settings.dcf renv/settings.dcf

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rocker/r-base:latest
 WORKDIR /project
 
 # R package dependencies
-RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev libgdal-dev
+RUN apt-get update && apt-get install -y libcurl4-openssl-dev libssl-dev libgdal-dev libudunits2-dev
 
 # renv
 RUN mkdir -p renv


### PR DESCRIPTION
Baby steps towards a containerised DIMEX implementation. Ideally, instead of directly running `cli.R` the Dockerfile should run a `server.R` that calls `cli.R` in response to requests.