### PR TITLE
Auto-build docs

### DIFF
--- a/DIMEX.Rproj
+++ b/DIMEX.Rproj
@@ -15,3 +15,4 @@ LaTeX: pdfLaTeX
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace


### PR DESCRIPTION
I think this change should mean that docs are also built by RStudio when the install button is clicked.